### PR TITLE
Interfaces

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -241,6 +241,7 @@ def count_neighbors(x: onp.ndarray) -> onp.ndarray:
         src=x.view(onp.uint8),
         kernel=_NEIGHBOR_KERNEL.view(onp.uint8),
         ddepth=-1,
+        borderType=cv2.BORDER_REPLICATE,
     )
 
 

--- a/metrics.py
+++ b/metrics.py
@@ -1,16 +1,31 @@
 """Defines functions that compute metrics for two-dimensional density arrays."""
 
-from typing import Callable, Tuple
+from typing import Callable, Sequence, Tuple
 
+import functools
 import cv2
 import numpy as onp
 
 
 # Specifies behavior in searching for the minimum length scale of an array.
-DEFAULT_NON_MONOTONIC_ALLOWANCE = 5
+NON_MONOTONIC_ALLOWANCE = 5
+
+# Specifies the default behavior for ignoring violations. We ignore violations
+# for any solid (void) pixel having exactly two solid (void) neighbors, which
+# corresponds to ignoring corners.
+IGNORED_PIXEL_NEIGHBOR_COUNTS = (2,)
 
 # "Plus-shaped" kernel used througout.
 _PLUS_KERNEL = onp.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], bool)
+
+# "Neighbor" kernel used to identify neighbors of a pixel.
+_NEIGHBOR_KERNEL = onp.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], bool)
+
+# Padding modes.
+_MODE_EDGE = "edge"
+_MODE_SOLID = "solid"
+_MODE_VOID = "void"
+
 
 # ------------------------------------------------------------------------------
 # Functions related to the length scale metric.
@@ -19,90 +34,160 @@ _PLUS_KERNEL = onp.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], bool)
 
 def minimum_length_scale(
     x: onp.ndarray,
-    ignore_interfaces: bool = True,
-    non_monotonic_allowance: int = DEFAULT_NON_MONOTONIC_ALLOWANCE,
+    ignored_pixel_neighbor_counts: Sequence[int] = IGNORED_PIXEL_NEIGHBOR_COUNTS,
+    non_monotonic_allowance: int = NON_MONOTONIC_ALLOWANCE,
+) -> Tuple[int, int]:
+    """Identifies the minimum length scale of solid and void features in `x`.
+
+    The minimum length scale for solid (void) features defines the largest brush
+    which can be used to recreate the solid (void) features in `x`, by convolving
+    an array of "touches" with the brush kernel. In general if an array can be
+    created with a given brush, then its solid and void features are unchanged by
+    binary opening operations with that brush.
+
+    In some cases, an array that can be creatied with a brush of size `n` cannot
+    be created with the samller brush if size `n - 1`. Further, small pixel-scale
+    violations at interfaces between large features may be unimportant. Some
+    allowance for these is provided via optional arguments to this function.
+
+    Args:
+      x: Bool-typed rank-2 array containing the features.
+      ignored_pixels_neighbor_counts: Specifies which pixels to ignore. Solid
+            pixels with neighbor counts among the given `neighbor_counts_to_ignore`
+            are marked to be ignored. See `ignored_pixels` for details.
+      non_monotonic_allowance: See `maximum_true_arg` for details.
+
+    Returns:
+      The detected minimum length scales `(length_scale_solid, length_scale_void)`.
+    """
+    return (
+        minimum_length_scale_solid(
+            x, ignored_pixel_neighbor_counts, non_monotonic_allowance
+        ),
+        minimum_length_scale_solid(
+            ~x, ignored_pixel_neighbor_counts, non_monotonic_allowance
+        ),
+    )
+
+
+def minimum_length_scale_solid(
+    x: onp.ndarray,
+    ignored_pixel_neighbor_counts: Sequence[int],
+    non_monotonic_allowance: int,
 ) -> int:
-  """Identifies the minimum length scale of features in boolean array `x`.
+    """Identifies the minimum length scale of solid features in `x`.
 
-  The minimum length scale for an array `x` is the largest value for which there
-  are no length scale violations. For a given length scale, there will be
-  violations if `x` cannot be created using a "brush" with diameter equal to the
-  length scale. In general, if an array can be created with a given brush, then
-  its solid and void features are unchanged by binary opening operations with
-  that brush.
+    Args:
+      x: Bool-typed rank-2 array containing the features.
+      ignored_pixel_neighbor_counts: Specifies which pixels to ignore. Solid
+            pixels with neighbor counts among the given `neighbor_counts_to_ignore`
+            are marked to be ignored. See `ignored_pixels` for details.
+      non_monotonic_allowance: See `maximum_true_arg` for details.
 
-  In some cases, an array that can be creatied with a brush of size `n` cannot
-  be created with the samller brush if size `n - 1`. Further, small pixel-scale
-  violations at interfaces between large features may be unimportant. Some
-  allowance for these is provided via optional arguments to this function.
-  
-  Args:
-    x: Bool-typed rank-2 array containing the features.
-    ignore_interfaces: Specifies whether violations at feature interfaces are
-      to be disregarded. 
-    non_monotonic_allowance: See `maximum_true_arg` for details.
+    Returns:
+      The detected minimum length scale of solid features.
+    """
+    assert x.dtype == bool
 
-  Returns:
-    The detected minimum length scale.
-  """
-  assert x.dtype == bool
+    def test_fn(scale: int) -> bool:
+        return ~onp.any(
+            length_scale_violations_solid(x, scale, ignored_pixel_neighbor_counts)
+        )
 
-  def test_fn(scale: int) -> bool:
-    return ~onp.any(length_scale_violations(x, scale, ignore_interfaces))
-
-  return maximum_true_arg(
-      nearly_monotonic_fn=test_fn,
-      min_arg=1,
-      max_arg=max(x.shape),
-      non_monotonic_allowance=non_monotonic_allowance)
+    return maximum_true_arg(
+        nearly_monotonic_fn=test_fn,
+        min_arg=1,
+        max_arg=max(x.shape),
+        non_monotonic_allowance=non_monotonic_allowance,
+    )
 
 
-def length_scale_violations(
+def length_scale_violations_solid(
     x: onp.ndarray,
     length_scale: int,
-    ignore_interfaces: bool,
+    ignored_pixel_neighbor_counts: Sequence[int],
 ) -> onp.ndarray:
-  """Identifies length scale violations of solid and void features in `x`.
-  
-  Optionally, the algorithm disregards pixel-scale violations that can exist at
-  the boundaries of features. This gives unpredictable results when features are
-  small, i.e. comparable to pixel scale.
+    """Identifies length scale violations of solid features in `x`.
 
-  Args:
-    x: Bool-typed rank-2 array containing the features.
-    length_scale: The length scale for which violations are sought.
-    ignore_interfaces: Specifies whether violations at feature interfaces are
-      to be disregarded. 
+    Args:
+      x: Bool-typed rank-2 array containing the features.
+      length_scale: The length scale for which violations are sought.
+      ignored_pixel_neighbor_counts: Specifies which pixels to ignore. Solid
+            pixels with neighbor counts among the given `neighbor_counts_to_ignore`
+            are marked to be ignored. See `ignored_pixels` for details.
 
-  Returns:
-    The array containing violations.
-  """
-  kernel = kernel_for_length_scale(length_scale)
-  return (brush_violations(x, kernel, ignore_interfaces) |
-          brush_violations(~x, kernel, ignore_interfaces))
+    Returns:
+      The array containing violations.
+    """
+    ignored = ignored_pixels(x, ignored_pixel_neighbor_counts)
+    kernel = kernel_for_length_scale(length_scale)
+    violations_solid_padding = ~ignored & (
+        x & ~binary_opening(x, kernel, mode=_MODE_SOLID)
+    )
+    violations_void_padding = ~ignored & (
+        x & ~binary_opening(x, kernel, mode=_MODE_VOID)
+    )
+    return ~(~violations_solid_padding | ~violations_void_padding)
+
+
+def ignored_pixels(
+    x: onp.ndarray,
+    ignored_pixels_neighbor_counts: Sequence[int],
+) -> onp.ndarray:
+    """Returns pixels for which length scale violations are to be ignored.
+
+    The function can be configured to select pixels that are solid, with varying
+    numbers of solid neighbors. Neighbors are considered in a 4-connected sense,
+    i.e. a solid pixel having four solid neighbors has solid pixels above, below,
+    to the left, and to the right.
+
+    Several example configurations for ignored pixels are as follows:
+        `()`: No violations are ignored.
+        `(0,)`: Ignores pixels with no neighbors, i.e. isolated single pixels.
+        `(1,)`: Ignores pixels with one neighbor, i.e. "single pixel penninsulas".
+        `(2,)`: Ignores pixels with two neighbors, i.e. corners.
+        `(0, 1, 2, 3)`: Ignores all pixels with a void neighbor, i.e. interfaces.
+
+    Args:
+        x: The array from which ignored pixels are selected.
+        ignored_pixels_neighbor_counts: Specifies which pixels to ignore. Solid
+            pixels with neighbor counts among the given `neighbor_counts_to_ignore`
+            are marked to be ignored.
+
+    Return:
+        The ignored pixels array.
+    """
+    if not all([n in (0, 1, 2, 3) for n in ignored_pixels_neighbor_counts]):
+        raise ValueError(
+            f"Valid neighbor counts are `(0, 1, 2, 3)`, got "
+            f"{ignored_pixels_neighbor_counts}."
+        )
+
+    neighbor_count = count_neighbors(x)
+    return x & onp.isin(neighbor_count, ignored_pixels_neighbor_counts)
 
 
 def kernel_for_length_scale(length_scale: int) -> onp.ndarray:
-  """Returns an approximately circular kernel for the given `length_scale`.
+    """Returns an approximately circular kernel for the given `length_scale`.
 
-  The kernel has shape `(length_scale, length_scale)`, and is `True` for pixels
-  whose centers lie within the circle of radius `length_scale / 2` centered on
-  the kernel. This yields a pixelated circle, which for length scales less than
-  `4` will actually be square.
-  
-  Args:
-    length_scale: The length scale for which the kernel is sought.
+    The kernel has shape `(length_scale, length_scale)`, and is `True` for pixels
+    whose centers lie within the circle of radius `length_scale / 2` centered on
+    the kernel. This yields a pixelated circle, which for length scales less than
+    `4` will actually be square.
 
-  Returns:
-    The approximately circular kernel.
-  """
-  assert length_scale > 0
-  centers = onp.arange(-length_scale / 2 + 0.5, length_scale / 2)
-  squared_distance = centers[:, onp.newaxis]**2 + centers[onp.newaxis, :]**2
-  kernel = squared_distance < (length_scale / 2)**2
-  # Ensure that the kernel can be realized with a width-3 brush.
-  kernel = binary_opening(kernel, _PLUS_KERNEL)
-  return kernel
+    Args:
+      length_scale: The length scale for which the kernel is sought.
+
+    Returns:
+      The approximately circular kernel.
+    """
+    assert length_scale > 0
+    centers = onp.arange(-length_scale / 2 + 0.5, length_scale / 2)
+    squared_distance = centers[:, onp.newaxis] ** 2 + centers[onp.newaxis, :] ** 2
+    kernel = squared_distance < (length_scale / 2) ** 2
+    # Ensure that the kernel can be realized with a width-3 brush.
+    kernel = binary_opening(kernel, _PLUS_KERNEL, mode=_MODE_VOID)
+    return kernel
 
 
 # ------------------------------------------------------------------------------
@@ -110,101 +195,105 @@ def kernel_for_length_scale(length_scale: int) -> onp.ndarray:
 # ------------------------------------------------------------------------------
 
 
-def brush_violations(
-    x: onp.ndarray,
-    kernel: onp.ndarray,
-    ignore_interfaces: bool,
-) -> onp.ndarray:
-  """Identifies brush violations of solid features in `x`.
-  
-  A brush violation is a pixel in `x` which is not present in the binary opening
-  of `x` with structuring element `kernel`.
+def binary_opening(x: onp.ndarray, kernel: onp.ndarray, mode: str) -> onp.ndarray:
+    """Performs binary opening with the given `kernel` and edge-mode padding.
 
-  Args:
-    x: Bool-typed rank-2 array containing the features.
-    kernel: Bool-typed rank-2 array containing the kernel.
-    ignore_interfaces: Specifies whether violations at feature interfaces are
-      to be disregarded. 
+    The edge-mode padding ensures that small features at the border of `x` are
+    not removed.
 
-  Returns:
-    The array containing violations.
-  """
-  violations = x & ~binary_opening(x, kernel)
-  if ignore_interfaces:
-    # If the interfaces are to be ignored, compute a mask that selects pixels
-    # that are within features, i.e. they are not interface pixels. Only those
-    # violations which overlap the mask are considered.
-    non_interface_pixels = ~(x & ~binary_erosion(x))
-    return violations & non_interface_pixels
-  return violations
+    Args:
+      x: Bool-typed rank-2 array to be transformed.
+      kernel: Bool-typed rank-2 array containing the kernel.
+      mode: The padding mode to be used. See `pad_2d` for details.
 
-
-def binary_opening(x: onp.ndarray, kernel: onp.ndarray) -> onp.ndarray:
-  """Performs binary opening with the given `kernel` and edge-mode padding.
-  
-  The edge-mode padding ensures that small features at the border of `x` are
-  not removed.
-
-  Args:
-    x: Bool-typed rank-2 array to be transformed.
-    kernel: Bool-typed rank-2 array containing the kernel.
-
-  Returns:
-    The transformed array.
-  """
-  assert x.ndim == 2
-  assert x.dtype == bool
-  assert kernel.ndim == 2
-  assert kernel.dtype == bool
-  pad_width = ((kernel.shape[0],) * 2, (kernel.shape[1],) * 2)
-  # Even-size kernels lead to shifts in the image content, which we need to
-  # correct by a shifted unpadding.
-  unpad_width = ((kernel.shape[0] + (kernel.shape[0] + 1) % 2,
-                  kernel.shape[0] - (kernel.shape[0] + 1) % 2,),
-                 (kernel.shape[1] + (kernel.shape[1] + 1) % 2,
-                  kernel.shape[1] - (kernel.shape[1] + 1) % 2,),)
-  opened = cv2.morphologyEx(
-      src=pad_2d_edge(x, pad_width).view(onp.uint8),
-      kernel=kernel.view(onp.uint8),
-      op=cv2.MORPH_OPEN)
-  return unpad(opened.view(bool), unpad_width)
+    Returns:
+      The transformed array.
+    """
+    assert x.ndim == 2
+    assert x.dtype == bool
+    assert kernel.ndim == 2
+    assert kernel.dtype == bool
+    pad_width = ((kernel.shape[0],) * 2, (kernel.shape[1],) * 2)
+    # Even-size kernels lead to shifts in the image content, which we need to
+    # correct by a shifted unpadding.
+    unpad_width = (
+        (
+            kernel.shape[0] + (kernel.shape[0] + 1) % 2,
+            kernel.shape[0] - (kernel.shape[0] + 1) % 2,
+        ),
+        (
+            kernel.shape[1] + (kernel.shape[1] + 1) % 2,
+            kernel.shape[1] - (kernel.shape[1] + 1) % 2,
+        ),
+    )
+    opened = cv2.morphologyEx(
+        src=pad_2d(x, pad_width, mode=mode).view(onp.uint8),
+        kernel=kernel.view(onp.uint8),
+        op=cv2.MORPH_OPEN,
+    )
+    return unpad(opened.view(bool), unpad_width)
 
 
-def binary_erosion(x: onp.ndarray) -> onp.ndarray:
-  """Performs binary erosion with a 2-connected kernel and edge padding."""
-  assert x.dtype == bool
-  pad_width = ((1, 1), (1, 1))
-  eroded = cv2.erode(
-      src=pad_2d_edge(x, pad_width).view(onp.uint8),
-      kernel=_PLUS_KERNEL.view(onp.uint8))
-  return unpad(eroded.view(bool), pad_width)
+def count_neighbors(x: onp.ndarray) -> onp.ndarray:
+    """Counts the solid neighbors of each pixel in `x`."""
+    assert x.dtype == bool
+    return cv2.filter2D(
+        src=x.view(onp.uint8),
+        kernel=_NEIGHBOR_KERNEL.view(onp.uint8),
+        ddepth=-1,
+    )
 
 
-def pad_2d_edge(
+def pad_2d(
     x: onp.ndarray,
     pad_width: Tuple[Tuple[int, int], Tuple[int, int]],
+    mode: str,
 ) -> onp.ndarray:
-  """Pads rank-2 boolean array `x` with edge pixel values."""
-  assert x.dtype == bool
-  ((top, bottom), (left, right)) = pad_width
-  # The `copyMakeBorder` operation is equivalent to `numpy.pad`, but is faster.
-  return cv2.copyMakeBorder(
-      x.view(onp.uint8), 
-      top=top,
-      bottom=bottom,
-      left=left,
-      right=right,
-      borderType=cv2.BORDER_REPLICATE).view(bool)
+    """Pads rank-2 boolean array `x` with the specified mode.
+
+    Padding may take values from the edge pixels, or be entirely solid or
+    void, determined by the `mode` parameter.
+
+    Args:
+      x: The array to be padded.
+      pad_width: The extent of the padding, `((i_lo, i_hi), (j_lo, j_hi))`.
+      mode: Either "edge", "solid", or "void".
+
+    Returns:
+      The padded array.
+    """
+    assert x.dtype == bool
+    ((top, bottom), (left, right)) = pad_width
+    pad_fn = functools.partial(
+        cv2.copyMakeBorder,
+        src=x.view(onp.uint8),
+        top=top,
+        bottom=bottom,
+        left=left,
+        right=right,
+    )
+    if mode == _MODE_EDGE:
+        return pad_fn(borderType=cv2.BORDER_REPLICATE).view(bool)
+    elif mode == _MODE_SOLID:
+        return pad_fn(borderType=cv2.BORDER_CONSTANT, value=1).view(bool)
+    elif mode == _MODE_VOID:
+        return pad_fn(borderType=cv2.BORDER_CONSTANT, value=0).view(bool)
+    else:
+        raise ValueError(f"Invalid `mode`, got {mode}.")
 
 
 def unpad(
     x: onp.ndarray,
     pad_width: Tuple[Tuple[int, int], ...],
 ) -> onp.ndarray:
-  """Undoes a pad operation."""
-  slices = tuple([slice(pad_lo, dim - pad_hi)
-                  for (pad_lo, pad_hi), dim in zip(pad_width, x.shape)])
-  return x[slices]
+    """Undoes a pad operation."""
+    slices = tuple(
+        [
+            slice(pad_lo, dim - pad_hi)
+            for (pad_lo, pad_hi), dim in zip(pad_width, x.shape)
+        ]
+    )
+    return x[slices]
 
 
 # ------------------------------------------------------------------------------
@@ -218,49 +307,49 @@ def maximum_true_arg(
     max_arg: int,
     non_monotonic_allowance: int,
 ) -> int:
-  """Searches for the maximum integer for which `nearly_monotonic_fn` is `True`.
+    """Searches for the maximum integer for which `nearly_monotonic_fn` is `True`.
 
-  This requires `nearly_monotonic_fn` to be approximately monotonically
-  decreasing, i.e. it should be `True` for small arguments and then `False` for
-  large arguments. Some allowance for "noisy" behavior at the transition is
-  controlled by `non_monotonic_allowance`.
-  
-  The input argument is checked in the range `[min_arg, max_arg]`, where both
-  values are positive. If `test_fn` is never `True`, `min_arg` is returned.
+    This requires `nearly_monotonic_fn` to be approximately monotonically
+    decreasing, i.e. it should be `True` for small arguments and then `False` for
+    large arguments. Some allowance for "noisy" behavior at the transition is
+    controlled by `non_monotonic_allowance`.
 
-  Note that the algorithm here assumes that `nearly_monotonic_fn` is expensive
-  to evaluate with large arguments, and so a "small first" search strategy is
-  employed. For this reason, `min_arg` must be positive.
+    The input argument is checked in the range `[min_arg, max_arg]`, where both
+    values are positive. If `test_fn` is never `True`, `min_arg` is returned.
 
-  Args:
-    monotonic_fn: The function for which the maximum `True` argument is sought.
-    min_arg: The minimum argument. Must be positive.
-    max_arg: The maximum argument. Must be greater than `min_arg.`
-    non_monotonic_allowance: The number of candidate arguments where the
-      function evaluates to `False` to be considered before concluding that the
-      maximum `True` argument is smaller than the candidates. Must be positive.
+    Note that the algorithm here assumes that `nearly_monotonic_fn` is expensive
+    to evaluate with large arguments, and so a "small first" search strategy is
+    employed. For this reason, `min_arg` must be positive.
 
-  Returns:
-    The maximum `True` argument, or `min_arg`.
-  """
-  assert min_arg > 0
-  assert min_arg < max_arg
-  assert non_monotonic_allowance > 0
-  
-  max_true_arg = min_arg - 1
-  
-  while min_arg <= max_arg:
-    # We double `min_arg` rather than bisecting, as this requires fewer
-    # evaluations when the minimum `True` value is close to `min_arg`.
-    test_arg_start = min(min_arg * 2, (min_arg + max_arg) // 2)
-    test_arg_stop = min(test_arg_start + non_monotonic_allowance, max_arg + 1)
-    for test_arg in range(test_arg_start, test_arg_stop):
-      result = nearly_monotonic_fn(test_arg)
-      if result:
-        break
-    if result:
-      min_arg = test_arg + 1
-      max_true_arg = max(max_true_arg, test_arg)
-    else:
-      max_arg = test_arg_start - 1
-  return max_true_arg
+    Args:
+      monotonic_fn: The function for which the maximum `True` argument is sought.
+      min_arg: The minimum argument. Must be positive.
+      max_arg: The maximum argument. Must be greater than `min_arg.`
+      non_monotonic_allowance: The number of candidate arguments where the
+        function evaluates to `False` to be considered before concluding that the
+        maximum `True` argument is smaller than the candidates. Must be positive.
+
+    Returns:
+      The maximum `True` argument, or `min_arg`.
+    """
+    assert min_arg > 0
+    assert min_arg < max_arg
+    assert non_monotonic_allowance > 0
+
+    max_true_arg = min_arg - 1
+
+    while min_arg <= max_arg:
+        # We double `min_arg` rather than bisecting, as this requires fewer
+        # evaluations when the minimum `True` value is close to `min_arg`.
+        test_arg_start = min(min_arg * 2, (min_arg + max_arg) // 2)
+        test_arg_stop = min(test_arg_start + non_monotonic_allowance, max_arg + 1)
+        for test_arg in range(test_arg_start, test_arg_stop):
+            result = nearly_monotonic_fn(test_arg)
+            if result:
+                break
+        if result:
+            min_arg = test_arg + 1
+            max_true_arg = max(max_true_arg, test_arg)
+        else:
+            max_arg = test_arg_start - 1
+    return max_true_arg

--- a/metrics_test.py
+++ b/metrics_test.py
@@ -8,8 +8,8 @@ import unittest
 
 import metrics
 
-TEST_ARRAY_4 = onp.array(
-    [  # Feasible with a diameter-4 brush.
+TEST_ARRAY_4_5 = onp.array(
+    [  # Solid features feasible with circle-4, void with circle-5.
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
         [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1],
@@ -19,8 +19,8 @@ TEST_ARRAY_4 = onp.array(
     ],
     dtype=bool,
 )
-TEST_ARRAY_5 = onp.array(
-    [  # Feasible with a diameter-5 brush.
+TEST_ARRAY_5_5 = onp.array(
+    [  # Solid features feasible with circle-5, void with circle-5.
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
         [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
@@ -28,6 +28,18 @@ TEST_ARRAY_5 = onp.array(
         [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
         [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1],
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+    ],
+    dtype=bool,
+)
+TEST_ARRAY_5_3 = onp.array(
+    [  # Solid features feasible with circle-5, void with circle-3.
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1],
+        [0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1],
+        [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1],
+        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
     ],
     dtype=bool,
 )
@@ -43,7 +55,8 @@ TEST_ARRAY_5_WITH_DEFECT = onp.array(
     ],
     dtype=bool,
 )
-TEST_ARRAYS = [TEST_ARRAY_4, TEST_ARRAY_5, TEST_ARRAY_5_WITH_DEFECT]
+TEST_ARRAYS = [TEST_ARRAY_4_5, TEST_ARRAY_5_5, TEST_ARRAY_5_3, TEST_ARRAY_5_WITH_DEFECT]
+
 
 TEST_KERNEL_4 = onp.array(
     [[0, 1, 1, 0], [1, 1, 1, 1], [1, 1, 1, 1], [0, 1, 1, 0]], dtype="bool"
@@ -64,15 +77,26 @@ TEST_KERNEL_4_3_ASYMMETRIC = onp.array(
 TEST_KERNELS = [TEST_KERNEL_4, TEST_KERNEL_5, TEST_KERNEL_4_3_ASYMMETRIC]
 
 
+IGNORE_NONE = ()
+IGNORE_PENINSULAS = (1,)
+IGNORE_INTERFACES = (0, 1, 2, 3)
+IGNORE_CORNERS = (2,)
+
+
 class LengthScaleTest(unittest.TestCase):
     @parameterized.parameterized.expand(
         [
-            (TEST_ARRAY_4, 4),
-            (TEST_ARRAY_5, 5),
+            (TEST_ARRAY_4_5, 4, 5),
+            (TEST_ARRAY_5_5, 5, 5),
+            (TEST_ARRAY_5_3, 5, 3),
         ]
     )
-    def test_length_scale_matches_expected(self, x, expected):
-        assert expected == metrics.minimum_length_scale(x, ignore_interfaces=False)
+    def test_length_scale_matches_expected(self, x, expected_solid, expected_void):
+        length_scale_solid, length_scale_void = metrics.minimum_length_scale(
+            x, IGNORE_NONE
+        )
+        self.assertEqual(length_scale_solid, expected_solid)
+        self.assertEqual(length_scale_void, expected_void)
 
     @parameterized.parameterized.expand([[i] for i in range(5, 20)])
     def test_circle_has_expected_length_scale(self, length_scale):
@@ -80,7 +104,11 @@ class LengthScaleTest(unittest.TestCase):
         # to the length scale. Pad to make sure the feature is isolated.
         x = metrics.kernel_for_length_scale(length_scale)
         x = onp.pad(x, ((1, 1), (1, 1)), mode="constant")
-        assert length_scale == metrics.minimum_length_scale(x)
+        length_scale_solid, length_scale_void = metrics.minimum_length_scale(
+            x, IGNORE_NONE
+        )
+        self.assertEqual(length_scale_solid, length_scale)
+        self.assertEqual(length_scale_void, min(x.shape))
 
     @parameterized.parameterized.expand([[i] for i in range(5, 20)])
     def test_hole_has_expected_length_scale(self, length_scale):
@@ -88,34 +116,42 @@ class LengthScaleTest(unittest.TestCase):
         # to the length scale. Pad to make sure the feature is isolated.
         x = metrics.kernel_for_length_scale(length_scale)
         x = onp.pad(x, ((1, 1), (1, 1)), mode="constant")
-        x = ~x
-        assert length_scale == metrics.minimum_length_scale(x)
+        length_scale_solid, length_scale_void = metrics.minimum_length_scale(
+            ~x, IGNORE_NONE
+        )
+        self.assertEqual(length_scale_void, length_scale)
+        self.assertEqual(length_scale_solid, min(x.shape))
 
     def test_brush_violations_with_interface_defects(self):
         # Assert that there are violations in the defective array.
         assert onp.any(
-            metrics.brush_violations(
-                TEST_ARRAY_5_WITH_DEFECT, TEST_KERNEL_4, ignore_interfaces=False
+            metrics.length_scale_violations_solid(
+                TEST_ARRAY_5_WITH_DEFECT, 4, IGNORE_NONE
             )
         )
         # Assert that there are no violations if we ignore interfaces.
         assert not onp.any(
-            metrics.brush_violations(
-                TEST_ARRAY_5_WITH_DEFECT, TEST_KERNEL_4, ignore_interfaces=True
+            metrics.length_scale_violations_solid(
+                TEST_ARRAY_5_WITH_DEFECT, 4, IGNORE_INTERFACES
+            )
+        )
+        # Assert that there are violations if we only ignore corners.
+        assert onp.any(
+            metrics.length_scale_violations_solid(
+                TEST_ARRAY_5_WITH_DEFECT, 4, IGNORE_CORNERS
             )
         )
 
-    @parameterized.parameterized.expand(
-        [
-            (TEST_ARRAY_4, TEST_KERNEL_4),
-            (TEST_ARRAY_5, TEST_KERNEL_5),
-        ]
-    )
-    def test_no_brush_violations_with_feasible_arrays(self, x, kernel):
-        onp.testing.assert_array_equal(
-            onp.zeros_like(x),
-            metrics.brush_violations(x, kernel, ignore_interfaces=False),
-        )
+    def test_solid_feature_shallow_incidence(self):
+        # Checks that the length scale for a design having a solid feature that
+        # is incident on the design edge with a very shallow angle has a length
+        # scale equal to the size of the design.
+        x = onp.ones((70, 70), dtype=bool)
+        x[-1, 10:] = 0
+        x[-2, 20:] = 0
+        length_scale_solid, length_scale_void = metrics.minimum_length_scale(x)
+        self.assertEqual(length_scale_solid, 70)
+        self.assertEqual(length_scale_void, 70)
 
 
 class KernelTest(unittest.TestCase):
@@ -126,21 +162,79 @@ class KernelTest(unittest.TestCase):
         )
 
 
+class IgnorePixelsTest(unittest.TestCase):
+    IGNORE_TEST_ARRAY = onp.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
+            [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+        ],
+        dtype=bool,
+    )
+
+    def test_ignore_none(self):
+        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, ())
+        onp.testing.assert_array_equal(ignored, onp.zeros_like(ignored))
+
+    def test_ignore_peninsula(self):
+        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, IGNORE_PENINSULAS)
+        expected = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        onp.testing.assert_array_equal(ignored, expected)
+
+    def test_ignore_corner(self):
+        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, IGNORE_CORNERS)
+        expected = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        onp.testing.assert_array_equal(ignored, expected)
+
+    def test_ignore_interfaces(self):
+        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, IGNORE_INTERFACES)
+        expected = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                [0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
+            ],
+            dtype=bool,
+        )
+        onp.testing.assert_array_equal(ignored, expected)
+
+
 # ------------------------------------------------------------------------------
 # Tests for array-manipulating functions.
 # ------------------------------------------------------------------------------
 
 
 class MorphologyOperationsTest(unittest.TestCase):
-    @parameterized.parameterized.expand([[arr] for arr in TEST_ARRAYS])
-    def test_erosion_matches_scipy(self, x):
-        x_padded = onp.pad(x, ((1, 1), (1, 1)), mode="edge")
-        kernel = onp.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], bool)
-        expected = ndimage.binary_erosion(x_padded, kernel)
-        expected = expected[1:-1, 1:-1]
-        actual = metrics.binary_erosion(x)
-        onp.testing.assert_array_equal(expected, actual)
-
     @parameterized.parameterized.expand(
         list(itertools.product(TEST_KERNELS, TEST_ARRAYS))
     )
@@ -152,11 +246,11 @@ class MorphologyOperationsTest(unittest.TestCase):
             pad_width[0][0] : expected.shape[0] - pad_width[0][1],
             pad_width[1][0] : expected.shape[1] - pad_width[1][1],
         ]
-        actual = metrics.binary_opening(x, kernel)
+        actual = metrics.binary_opening(x, kernel, mode="edge")
         onp.testing.assert_array_equal(expected, actual)
 
     def test_opening_removes_small_features(self):
-        actual = metrics.binary_opening(TEST_ARRAY_4, TEST_KERNEL_5)
+        actual = metrics.binary_opening(TEST_ARRAY_4_5, TEST_KERNEL_5, mode="edge")
         expected = onp.array(
             [
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -177,12 +271,21 @@ class MorphologyOperationsTest(unittest.TestCase):
             [((4, 2), (5, 1))],
         ],
     )
-    def test_pad_2d_edge_matches_numpy(self, pad_width):
+    def test_pad_2d_matches_numpy(self, pad_width):
         onp.random.seed(0)
         x = onp.random.rand(20, 30) > 0.5  # Random binary array.
-        expected = onp.pad(x, pad_width, mode="edge")
-        actual = metrics.pad_2d_edge(x, pad_width)
-        onp.testing.assert_array_equal(expected, actual)
+        with self.subTest("edge"):
+            expected = onp.pad(x, pad_width, mode="edge")
+            actual = metrics.pad_2d(x, pad_width, mode="edge")
+            onp.testing.assert_array_equal(expected, actual)
+        with self.subTest("solid"):
+            expected = onp.pad(x, pad_width, constant_values=True)
+            actual = metrics.pad_2d(x, pad_width, mode="solid")
+            onp.testing.assert_array_equal(expected, actual)
+        with self.subTest("void"):
+            expected = onp.pad(x, pad_width, constant_values=False)
+            actual = metrics.pad_2d(x, pad_width, mode="void")
+            onp.testing.assert_array_equal(expected, actual)
 
     @parameterized.parameterized.expand(
         [

--- a/metrics_test.py
+++ b/metrics_test.py
@@ -163,25 +163,12 @@ class KernelTest(unittest.TestCase):
 
 
 class IgnorePixelsTest(unittest.TestCase):
-    IGNORE_TEST_ARRAY = onp.array(
-        [
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-            [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
-            [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
-            [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
-        ],
-        dtype=bool,
-    )
-
     def test_ignore_none(self):
-        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, ())
+        ignored = metrics.ignored_pixels(TEST_ARRAY_5_WITH_DEFECT, ())
         onp.testing.assert_array_equal(ignored, onp.zeros_like(ignored))
 
     def test_ignore_peninsula(self):
-        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, IGNORE_PENINSULAS)
+        ignored = metrics.ignored_pixels(TEST_ARRAY_5_WITH_DEFECT, IGNORE_PENINSULAS)
         expected = onp.array(
             [
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -197,7 +184,7 @@ class IgnorePixelsTest(unittest.TestCase):
         onp.testing.assert_array_equal(ignored, expected)
 
     def test_ignore_corner(self):
-        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, IGNORE_CORNERS)
+        ignored = metrics.ignored_pixels(TEST_ARRAY_5_WITH_DEFECT, IGNORE_CORNERS)
         expected = onp.array(
             [
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -213,7 +200,7 @@ class IgnorePixelsTest(unittest.TestCase):
         onp.testing.assert_array_equal(ignored, expected)
 
     def test_ignore_interfaces(self):
-        ignored = metrics.ignored_pixels(self.IGNORE_TEST_ARRAY, IGNORE_INTERFACES)
+        ignored = metrics.ignored_pixels(TEST_ARRAY_5_WITH_DEFECT, IGNORE_INTERFACES)
         expected = onp.array(
             [
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -263,6 +250,21 @@ class MorphologyOperationsTest(unittest.TestCase):
             dtype=bool,
         )
         onp.testing.assert_array_equal(expected, actual)
+
+    def test_count_neighbors(self):
+        neighbors = metrics.count_neighbors(TEST_ARRAY_5_WITH_DEFECT)
+        expected = onp.array(
+            [  
+                [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 2, 2, 3, 2, 2, 0, 0, 0, 0, 0, 0, 0],
+                [1, 2, 4, 4, 4, 1, 1, 0, 0, 0, 0, 1, 1],
+                [1, 3, 4, 4, 3, 3, 0, 0, 0, 0, 2, 2, 3],
+                [1, 2, 4, 4, 4, 1, 1, 0, 0, 1, 2, 4, 4],
+                [0, 2, 2, 3, 2, 2, 0, 0, 0, 1, 3, 4, 4],
+                [0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 3, 4, 4],
+            ],
+        )
+        onp.testing.assert_array_equal(neighbors, expected)
 
     @parameterized.parameterized.expand(
         [


### PR DESCRIPTION
Major rewrite with the following changes.

- Change `minimum_length_scale` API to return both the solid and void minimum length scale.
- Introduce the concept of a "feasibility gap" when checking for violations.
- Add flexibility in specifying locations at which violations should be ignored, including a new mode which only ignores the edges of large features.